### PR TITLE
Added an infix control character to stop the bot from pinging users

### DIFF
--- a/src/main/java/net/blay09/mods/eirairc/util/MessageFormat.java
+++ b/src/main/java/net/blay09/mods/eirairc/util/MessageFormat.java
@@ -65,7 +65,7 @@ public class MessageFormat {
 	}
 
 	public static String addPreSuffix(String name) {
-		return GlobalConfig.nickPrefix + name + GlobalConfig.nickSuffix;
+		return GlobalConfig.nickPrefix + name.substring(0, 1) + Character.toString((char)0x0081) + name.substring(1) + GlobalConfig.nickSuffix;
 	}
 
 	private static String filterAllowedCharacters(String message) {


### PR DESCRIPTION
This fix will make it so nicknames don't ping IRC users. It adds an invisible character after the nickname's firts character. After trying a few characters, \u0081 seemed the most stable (zero width space has poor support it seems, although this is the character you're supposed to use). Unfortunately, Minecraft doesn't have a proper empty glyph for this, so I can't just alias my nick as N\u0081ickname, hence this fix. Hopefully this PR will inspire you to put a proper implementation in EiraIRC :)

Thanks for all the great work btw, we're loving your mod