### PR TITLE
fix allow private message flag check on send

### DIFF
--- a/src/main/java/net/blay09/mods/eirairc/command/CommandMessage.java
+++ b/src/main/java/net/blay09/mods/eirairc/command/CommandMessage.java
@@ -52,7 +52,7 @@ public class CommandMessage extends SubCommand {
 			return true;
 		} else if(target instanceof IRCUserImpl) {
 			IRCBot bot = target.getConnection().getBot();
-			if(bot.getBoolean(target, BotProfile.KEY_ALLOWPRIVMSG, true)) {
+			if(!bot.getBoolean(target, BotProfile.KEY_ALLOWPRIVMSG, true)) {
 				Utils.sendLocalizedMessage(sender, "irc.msg.disabled");
 				return true;
 			}


### PR DESCRIPTION
Related to #105 I found one of the issues: the check for enabled private messages flag was reversed. While receiving it checks to be true but on send it does the opposite. Consider this one-character-fix :)
