### PR TITLE
Clear colorBlacklist before adding entries

### DIFF
--- a/src/main/java/net/blay09/mods/eirairc/config/SharedGlobalConfig.java
+++ b/src/main/java/net/blay09/mods/eirairc/config/SharedGlobalConfig.java
@@ -59,6 +59,7 @@ public class SharedGlobalConfig {
 		enablePlayerAliases = thisConfig.getBoolean("enablePlayerAliases", GENERAL, enablePlayerAliases, I19n.format("eirairc:config.property.enablePlayerAliases.tooltip"), "eirairc:config.property.enablePlayerAliases");
 		enablePlayerColors = thisConfig.getBoolean("enablePlayerColors", GENERAL, enablePlayerColors, I19n.format("eirairc:config.property.enablePlayerColors.tooltip"), "eirairc:config.property.enablePlayerColors");
 		String[] colorBlacklistArray = thisConfig.getStringList("colorBlacklist", GENERAL, Globals.DEFAULT_COLOR_BLACKLIST, I19n.format("eirairc:config.property.colorBlacklist.tooltip"), null, "eirairc:config.property.colorBlacklist");
+		colorBlacklist.clear();
 		for(String entry : colorBlacklistArray) {
 			colorBlacklist.add(entry);
 		}
@@ -124,6 +125,7 @@ public class SharedGlobalConfig {
 		enablePlayerAliases = legacyConfig.getBoolean("enableAliases", "serveronly", enablePlayerAliases, "");
 		enablePlayerColors = legacyConfig.getBoolean("enableNameColors", "display", enablePlayerColors, "");
 		String[] colorBlacklistArray = legacyConfig.getStringList("colorBlackList", "serveronly", new String[0], "");
+		colorBlacklist.clear();
 		for(String entry : colorBlacklistArray) {
 			colorBlacklist.add(Utils.unquote(entry));
 		}


### PR DESCRIPTION
*This commit has not been tested for compilation errors or bugs*

Prevents duplication of color blacklist entries in memory. Incidentally also [causes entries to double](http://i.imgur.com/PzcZTwN.png) in the shared config file after each reload, but this is indicative of another bug (https://github.com/blay09/EiraIRC/issues/180)